### PR TITLE
List applicationRoot at the end among all modules

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeContext.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/dev/DevModeContext.java
@@ -213,8 +213,8 @@ public class DevModeContext implements Serializable {
 
     public List<ModuleInfo> getAllModules() {
         List<ModuleInfo> ret = new ArrayList<>();
-        ret.add(applicationRoot);
         ret.addAll(additionalModules);
+        ret.add(applicationRoot);
         return ret;
     }
 


### PR DESCRIPTION
In RuntimeUpdateProcessor:636 the first module to be traversed is always applicationRoot. Whenever a breaking change (e.g, a change in method signature) is made in another module, applicationRoot will always be compiled first. This will result in a compile error. ApplicationRoot should always be the last module to be compiled.